### PR TITLE
fix pagination when using query string parameters

### DIFF
--- a/src/GatherContent/LaravelFractal/LaravelFractalService.php
+++ b/src/GatherContent/LaravelFractal/LaravelFractalService.php
@@ -56,6 +56,7 @@ class LaravelFractalService
     {
         if (is_null($adapter)) {
             $adapter = new IlluminatePaginatorAdapter($paginator);
+            $adapter->appends(\Request::query());
         }
         
         $collection->setPaginator($adapter);


### PR DESCRIPTION
for example i have query string parameter per_page = 30
meta information doesn't keep that parameter in pagination.
